### PR TITLE
feat: 메인 페이지 구현(#5)

### DIFF
--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -1,3 +1,19 @@
+"use client";
+import PokemonCardContainer from "@components/PokemonCardContainer";
+import useFetch from "@hooks/useFetch";
+
 export default function Home() {
-  return <div>Hello Next</div>;
+  const { data, isLoading, error } = useFetch("api/pokemon");
+
+  if (isLoading) return <div>로딩 중입니다.</div>;
+  if (error) return <div>문제가 발생했습니다.</div>;
+  if (data === null) return <div>데이터가 없습니다.</div>;
+
+  const { allPokemonData } = data;
+
+  return (
+    <div>
+      <PokemonCardContainer pokemonData={allPokemonData} />
+    </div>
+  );
 }

--- a/components/PokemonCard.tsx
+++ b/components/PokemonCard.tsx
@@ -1,0 +1,21 @@
+import Image from "next/image";
+import { PokeData } from "@custom-types/types";
+import { useRouter } from "next/navigation";
+
+export const PokemonCard = ({ front, name, id }: PokeData) => {
+  const router = useRouter();
+
+  return (
+    <div
+      className="flex w-[160px] flex-col items-center justify-center rounded-lg border-2 border-gray-200 p-4 shadow-md duration-100 hover:scale-110 hover:border-r-red-600 hover:border-b-red-600"
+      onClick={() => router.push(`/detail/${id}`)}
+      role="button"
+      tabIndex={0}
+    >
+      <div>
+        <Image src={front} alt={name} width={96} height={96} />
+      </div>
+      <div className="font-[NeoDunggeunmo]">{name}</div>
+    </div>
+  );
+};

--- a/components/PokemonCardContainer.tsx
+++ b/components/PokemonCardContainer.tsx
@@ -1,0 +1,17 @@
+import { PokemonCard } from "@components/PokemonCard";
+import { PokeData } from "@custom-types/types";
+
+interface PokemonCardContainerProps {
+  pokemonData: PokeData[];
+}
+
+const PokemonCardContainer = ({ pokemonData }: PokemonCardContainerProps) => {
+  return (
+    <section className="mx-auto grid w-fit grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-7">
+      {pokemonData.map((pokemon) => (
+        <PokemonCard key={pokemon.id} {...pokemon} />
+      ))}
+    </section>
+  );
+};
+export default PokemonCardContainer;

--- a/hooks/useFetch.ts
+++ b/hooks/useFetch.ts
@@ -1,0 +1,30 @@
+import { useState, useEffect } from "react";
+
+const useFetch = (url: string, options?: RequestInit) => {
+  const [data, setData] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setIsLoading(true);
+      try {
+        const response = await fetch(url, options);
+        const data = await response.json();
+        setData(data);
+      } catch (error) {
+        if (error instanceof Error) {
+          setError(error);
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [url, options]);
+
+  return { data, isLoading, error };
+};
+
+export default useFetch;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,11 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      new URL("https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/*"),
+    ],
+  },
 };
 
 export default nextConfig;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,8 @@
       "@app/": ["./app/*"],
       "@custom-types/*": ["./types/*"],
       "@api/*": ["./api/*"],
-      "@components/*": ["./components/*"]
+      "@components/*": ["./components/*"],
+      "@hooks/*": ["./hooks/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## #️⃣연관된 이슈

> #5

## 📝작업 내용

> 메인 페이지 구현
- 카드 컴포넌트 구현
- 카드 컨테이너 컴포넌트 구현
- api에서 데이터 받아와서 뿌려주기
- useFetch 훅 사용
- 절대경로에 hooks 추가

